### PR TITLE
Keep urllib3 version lower than 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ git+https://github.com/crunchr/requests-kerberos.git
 kerberos==1.3.0
 python-jenkins>=1.4.0
 PyOpenSSL
+urllib3==1.26.14


### PR DESCRIPTION
urllib3 library does not use socket._GLOBAL_DEFAULT_TIMEOUT as it's default value starting from version 2.0.0